### PR TITLE
Fixed connected button style

### DIFF
--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -61,7 +61,7 @@ export const RainbowKitCustomConnectButton = () => {
                     <button
                       onClick={openAccountModal}
                       type="button"
-                      className="btn btn-secondary btn-sm pl-0 pr-2 shadow-md"
+                      className="btn btn-primary btn-sm pl-0 pr-2 shadow-md"
                     >
                       <BlockieAvatar address={account.address} size={24} ensImage={account.ensAvatar} />
                       <span className="ml-2 mr-1">{account.displayName}</span>


### PR DESCRIPTION
Hello there, just doing this tiny fix cause I realised recently that the connect button was of this red color, looking like you're in the wrong network even when it's not the case:

<img width="358" alt="Captura de pantalla 2025-05-08 a las 13 33 30" src="https://github.com/user-attachments/assets/29153797-cc20-4170-84f6-3d234f642864" />

So I just adjusted the button style and now it looks like this:

<img width="376" alt="Captura de pantalla 2025-05-08 a las 13 54 58" src="https://github.com/user-attachments/assets/b807eedf-9a03-4a7e-a280-fd49702035ab" />

Thank you!